### PR TITLE
Added server name and host variables to mail template

### DIFF
--- a/classes/EmailMethod.php
+++ b/classes/EmailMethod.php
@@ -77,6 +77,9 @@ class EmailMethod implements Method
         ));
         $twig = new \Twig_Environment($loader);
 
+        $data['serverName'] = \Request::instance()->server('SERVER_NAME');
+        $data['host'] = \Request::instance()->getSchemeAndHttpHost();
+
         $subject = $twig->render('subject', $data);
         Mail::queue('ebussola.feedback::base-email', ['content' => $twig->render('main', $data)], function (Message $message) use ($sendTo, $subject, $data) {
             $message->subject($subject);

--- a/updates/adding_template_field_email_method.php
+++ b/updates/adding_template_field_email_method.php
@@ -8,7 +8,7 @@ class AddingTemplateFieldEmailMethod extends \Seeder
     {
         $defaultChannel = Channel::query()->where('code', 'default')->first();
         if ($defaultChannel) {
-            $defaultChannel->method_data = ['template' => '<h1>You have just received a feedback from your site!</h1>
+            $defaultChannel->method_data = ['template' => '<h1>You have just received a feedback from your site <a href="{{ host }}">{{ serverName }}</a>!</h1>
 <p>
     Here is the contact information: {{ name }} &lt;<a href="mailto:{{ email }}">{{ email }}</a>&gt; <br>
 </p>


### PR DESCRIPTION
Hi Leonardo, i have made server name and server host variables available in email template.
It is very useful in cases, when a user has several sites with `Feedback` plugin and need to see what site a feedback come from.
